### PR TITLE
Write the object

### DIFF
--- a/lib/fieldy/writer.rb
+++ b/lib/fieldy/writer.rb
@@ -4,8 +4,14 @@ module Fieldy
 
     def self.included(base)
       base.extend(WriterMethods)
+      base.send :include, InstanceMethods
     end
       
+    module InstanceMethods
+      def write
+        ''
+      end
+    end
 
     module WriterMethods
       

--- a/lib/fieldy/writer.rb
+++ b/lib/fieldy/writer.rb
@@ -9,7 +9,12 @@ module Fieldy
       
     module InstanceMethods
       def write
-        ''
+        fields = self.class.instance_eval { @fields }
+        data = fields.reduce({}) do |t, i|
+                 key = i.keys.first
+                 t.merge!(key => self.send(key))
+               end
+        self.class.write data
       end
     end
 

--- a/spec/fieldy/writer_spec.rb
+++ b/spec/fieldy/writer_spec.rb
@@ -18,4 +18,17 @@ describe Fieldy::Writer do
 
   end
 
+  describe "writing an instance of a file" do
+
+    it "should return the full line" do
+
+      file = AnotherFile.new.tap do |f|
+               f.first_name = 'test1'
+               f.last_name  = 'test2'
+             end
+      file.write.must_equal('test1 test2 ') 
+    end
+
+  end
+
 end

--- a/spec/fieldy/writer_spec.rb
+++ b/spec/fieldy/writer_spec.rb
@@ -35,10 +35,10 @@ describe Fieldy::Writer do
     it "should return the full line" do
 
       file = AnotherFile.new.tap do |f|
-               f.first_name = 'test1'
+               f.first_name = 'test'
                f.last_name  = 'test2'
              end
-      file.write.must_equal('test1 test2 ') 
+      file.write.must_equal('test test2') 
     end
 
   end


### PR DESCRIPTION
Add a `.write` to instances, so they can be dumped as a fixed-length string.
